### PR TITLE
Add read-only and full-access policies for AWS Pinpoint mobiletargeting

### DIFF
--- a/docs/provides.md
+++ b/docs/provides.md
@@ -176,6 +176,26 @@ Flag indicating whether SNS read-only access was requested.
 
 Flag indicating whether SNS full access was requested.
 
+<h2 id="provides.IntegrationRequest.requested_mobiletargeting_readonly">requested_mobiletargeting_readonly</h2>
+
+
+Flag indicating whether Pinpoint mobiletargeting read-only access was requested.
+
+<h2 id="provides.IntegrationRequest.requested_mobiletargeting_fullaccess">requested_mobiletargeting_fullaccess</h2>
+
+
+Flag indicating whether Pinpoint mobiletargeting full access was requested.
+
+<h2 id="provides.IntegrationRequest.requested_sms_voice_readonly">requested_sms_voice_readonly</h2>
+
+
+Flag indicating whether Pinpoint sms-voice read-only access was requested.
+
+<h2 id="provides.IntegrationRequest.requested_sms_voice_fullaccess">requested_sms_voice_fullaccess</h2>
+
+
+Flag indicating whether Pinpoint sms-voice full access was requested.
+
 <h2 id="provides.IntegrationRequest.unit_name">unit_name</h2>
 
 

--- a/docs/requires.md
+++ b/docs/requires.md
@@ -140,6 +140,38 @@ AWSIntegrationRequires.enable_sns_fullaccess(self)
 
 Request fullaccess for SNS.
 
+<h2 id="requires.AWSIntegrationRequires.enable_mobiletargeting_readonly">enable_mobiletargeting_readonly</h2>
+
+```python
+AWSIntegrationRequires.enable_mobiletargeting_readonly(self)
+```
+
+Request readonly for Pinpoint mobietargeting.
+
+<h2 id="requires.AWSIntegrationRequires.enable_mobiletargeting_fullaccess">enable_mobiletargeting_fullaccess</h2>
+
+```python
+AWSIntegrationRequires.enable_mobiletargeting_fullaccess(self)
+```
+
+Request fullaccess for Pinpoint mobiletargeting.
+
+<h2 id="requires.AWSIntegrationRequires.enable_sms_voice_readonly">enable_sms_voice_readonly</h2>
+
+```python
+AWSIntegrationRequires.enable_sms_voice_readonly(self)
+```
+
+Request readonly for Pinpoint sms-voice.
+
+<h2 id="requires.AWSIntegrationRequires.enable_sms_voice_fullaccess">enable_sms_voice_fullaccess</h2>
+
+```python
+AWSIntegrationRequires.enable_sms_voice_fullaccess(self)
+```
+
+Request fullaccess for Pinpoint sms-voice.
+
 <h2 id="requires.AWSIntegrationRequires.enable_instance_inspection">enable_instance_inspection</h2>
 
 ```python

--- a/provides.py
+++ b/provides.py
@@ -330,3 +330,31 @@ class IntegrationRequest:
         Flag indicating whether sns fullaccess was requested.
         """
         return bool(self._unit.received['enable-sns-fullaccess'])
+
+    @property
+    def requested_mobiletargeting_readonly(self):
+        """
+        Flag indicating whether pinpoint mobiletargeting readonly was requested.
+        """
+        return bool(self._unit.received['enable-mobiletargeting-readonly'])
+
+    @property
+    def requested_mobiletargeting_fullaccess(self):
+        """
+        Flag indicating whether pinpoint mobiletargeting fullaccess was requested.
+        """
+        return bool(self._unit.received['enable-mobiletargeting-fullaccess'])
+
+    @property
+    def requested_sms_voice_readonly(self):
+        """
+        Flag indicating whether pinpoint sms voice readonly was requested.
+        """
+        return bool(self._unit.received['enable-sms-voice-readonly'])
+
+    @property
+    def requested_sms_voice_fullaccess(self):
+        """
+        Flag indicating whether pinpoint sms voice fullaccess was requested.
+        """
+        return bool(self._unit.received['enable-sms-voice-fullaccess'])

--- a/requires.py
+++ b/requires.py
@@ -284,3 +284,28 @@ class AWSIntegrationRequires(Endpoint):
         Request fullaccess for SNS.
         """
         self._request({'enable-sns-fullaccess': True})
+
+    def enable_mobiletargeting_readonly(self):
+        """
+        Request readonly for mobiletargeting.
+        """
+        self._request({'enable-mobiletargeting-readonly': True})
+
+    def enable_mobiletargeting_fullaccess(self):
+        """
+        Request fullaccess for mobiletargeting.
+        """
+        self._request({'enable-mobiletargeting-fullaccess': True})
+
+    def enable_sms_voice_readonly(self):
+        """
+        Request readonly for sms-voice.
+        """
+        self._request({'enable-sms-voice-readonly': True})
+
+    def enable_sms_voice_fullaccess(self):
+        """
+        Request fullaccess for sms-voice.
+        """
+        self._request({'enable-sms-voice-fullaccess': True})
+


### PR DESCRIPTION
and sms-voice action prefixes

Ref:
https://docs.aws.amazon.com/pinpoint/latest/developerguide/security_iam_service-with-iam.html

fyi: @charness 